### PR TITLE
🗃️ : profile 컬럼 제약 조건 삭제, ✨ : swagger 적용, ♻️ : response 통일  / ❗

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'net.nurigo:sdk:4.3.0'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/capstone03/goldenglobe/ApiResponse.java
+++ b/src/main/java/com/capstone03/goldenglobe/ApiResponse.java
@@ -1,0 +1,27 @@
+package com.capstone03.goldenglobe;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ApiResponse<T> {
+    private final int status;
+    private final String message;
+    private final T data;
+
+    // 반환 데이터 X
+    public ApiResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+        this.data = null;
+    }
+
+    // 반환 데이터 O
+    public ApiResponse(int status, String message, T data) {
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+}

--- a/src/main/java/com/capstone03/goldenglobe/MyExceptionHandler.java
+++ b/src/main/java/com/capstone03/goldenglobe/MyExceptionHandler.java
@@ -12,33 +12,27 @@ import java.util.Map;
 public class MyExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException e) {
-        Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("status", 400);
-        errorResponse.put("message", "클라이언트 오류: " + e.getMessage());
+    public ResponseEntity<ApiResponse<String>> handleIllegalArgumentException(IllegalArgumentException e) {
+        ApiResponse<String> errorResponse = new ApiResponse<>(400, "클라이언트 오류: " + e.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<Map<String, Object>> handleGeneralException(Exception e) {
-        Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("status", 500);
-        errorResponse.put("message", "서버 내부 오류: " + e.getMessage());
+    public ResponseEntity<ApiResponse<String>> handleGeneralException(Exception e) {
+        ApiResponse<String> errorResponse = new ApiResponse<>(500, "서버 내부 오류: " + e.getMessage());
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
     }
 
     @ExceptionHandler(NullPointerException.class)
-    public ResponseEntity<Map<String, Object>> handleNullPointerException(NullPointerException ex) {
+    public ResponseEntity<ApiResponse<String>> handleNullPointerException(NullPointerException e) {
         // auth가 null일 때 예외 처리
-        if (ex.getMessage().contains("org.springframework.security.core.Authentication.getPrincipal()")) {
-            Map<String, Object> response = new HashMap<>();
-            response.put("status", 401);
-            response.put("message", "인증되지 않은 사용자입니다.");
-
+        if (e.getMessage().contains("org.springframework.security.core.Authentication.getPrincipal()")) {
+            ApiResponse<String> response = new ApiResponse<>(401, "인증되지 않은 사용자입니다.");
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
         }
         // 다른 이유로 null이 뜰 경우
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(null);
+        ApiResponse<String> response = new ApiResponse<>(500, "서버 내부 오류: "+e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
     }
 
 }

--- a/src/main/java/com/capstone03/goldenglobe/checkList/CheckListController.java
+++ b/src/main/java/com/capstone03/goldenglobe/checkList/CheckListController.java
@@ -1,5 +1,7 @@
 package com.capstone03.goldenglobe.checkList;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -14,10 +16,12 @@ import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
+@Tag(name="CheckList",description = "체크리스트  API")
 public class CheckListController {
     private final CheckListService checkListService;
 
     @PostMapping("/checklists")
+    @Operation(summary="체크리스트 생성",description = "주어진 목적지Id에 대한 체크리스트 생성. 현재는 여행지 설정 시 자동으로 생성되므로 필요 없는 API")
     public ResponseEntity<Map<String, Object>> postChecklist(@RequestParam Long destId,Authentication auth) {
         String listId = checkListService.makeCheckList(destId,auth);
         Map<String, Object> response = new HashMap<>();
@@ -28,6 +32,7 @@ public class CheckListController {
     }
 
     @GetMapping("/checklists/{dest_id}")
+    @Operation(summary = "체크리스트 조회",description = "주어진 목적지Id에 대한 체크리스트 전체 조회(그룹, 메모, 항목)")
     public ResponseEntity<Map<String, Object>> getCheckList(@PathVariable("dest_id") Long dest_id,Authentication auth) {
         System.out.println("controller 실행");
         Map<String, Object> response = checkListService.getCheckListDetails(dest_id,auth);

--- a/src/main/java/com/capstone03/goldenglobe/checkList/CheckListController.java
+++ b/src/main/java/com/capstone03/goldenglobe/checkList/CheckListController.java
@@ -1,5 +1,6 @@
 package com.capstone03.goldenglobe.checkList;
 
+import com.capstone03.goldenglobe.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -22,20 +23,17 @@ public class CheckListController {
 
     @PostMapping("/checklists")
     @Operation(summary="체크리스트 생성",description = "주어진 목적지Id에 대한 체크리스트 생성. 현재는 여행지 설정 시 자동으로 생성되므로 필요 없는 API")
-    public ResponseEntity<Map<String, Object>> postChecklist(@RequestParam Long destId,Authentication auth) {
+    public ResponseEntity<ApiResponse<String>> postChecklist(@RequestParam Long destId, Authentication auth) {
         String listId = checkListService.makeCheckList(destId,auth);
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "체크리스트 추가 성공");
-        response.put("list_id", listId);
+        ApiResponse<String> response = new ApiResponse<>(200, "체크리스트 추가 성공", listId);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/checklists/{dest_id}")
     @Operation(summary = "체크리스트 조회",description = "주어진 목적지Id에 대한 체크리스트 전체 조회(그룹, 메모, 항목)")
-    public ResponseEntity<Map<String, Object>> getCheckList(@PathVariable("dest_id") Long dest_id,Authentication auth) {
-        System.out.println("controller 실행");
-        Map<String, Object> response = checkListService.getCheckListDetails(dest_id,auth);
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getCheckList(@PathVariable("dest_id") Long dest_id,Authentication auth) {
+        Map<String, Object> data = checkListService.getCheckListDetails(dest_id,auth);
+        ApiResponse<Map<String, Object>> response = new ApiResponse<>(200, "체크리스트 조회 성공", data);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/capstone03/goldenglobe/checkList/CheckListController.java
+++ b/src/main/java/com/capstone03/goldenglobe/checkList/CheckListController.java
@@ -12,9 +12,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import java.util.HashMap;
-import java.util.Map;
-
 @Controller
 @RequiredArgsConstructor
 @Tag(name="CheckList",description = "체크리스트  API")
@@ -31,9 +28,9 @@ public class CheckListController {
 
     @GetMapping("/checklists/{dest_id}")
     @Operation(summary = "체크리스트 조회",description = "주어진 목적지Id에 대한 체크리스트 전체 조회(그룹, 메모, 항목)")
-    public ResponseEntity<ApiResponse<Map<String, Object>>> getCheckList(@PathVariable("dest_id") Long dest_id,Authentication auth) {
-        Map<String, Object> data = checkListService.getCheckListDetails(dest_id,auth);
-        ApiResponse<Map<String, Object>> response = new ApiResponse<>(200, "체크리스트 조회 성공", data);
+    public ResponseEntity<ApiResponse<CheckListResponseDTO>> getCheckList(@PathVariable("dest_id") Long dest_id, Authentication auth) {
+        CheckListResponseDTO toDto = checkListService.getCheckListDetails(dest_id,auth);
+        ApiResponse<CheckListResponseDTO> response = new ApiResponse<>(200, "체크리스트 조회 성공", toDto);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/capstone03/goldenglobe/checkList/CheckListResponseDTO.java
+++ b/src/main/java/com/capstone03/goldenglobe/checkList/CheckListResponseDTO.java
@@ -1,0 +1,18 @@
+package com.capstone03.goldenglobe.checkList;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CheckListResponseDTO {
+    private String listId;
+    private List<GroupResponseDTO> groups;
+}
+

--- a/src/main/java/com/capstone03/goldenglobe/checkList/CheckListService.java
+++ b/src/main/java/com/capstone03/goldenglobe/checkList/CheckListService.java
@@ -55,7 +55,7 @@ public class CheckListService {
 
         CheckList checkList = optionalCheckList.get();
 
-        // 유저 권한 확인 절차
+        // 유저 권한 확인 절차 >> 수정 필요!!!!
         if (!authCheck.hasAccessToCheckList(checkList.getListId(), auth)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "체크리스트에 접근할 수 없습니다.");
         }

--- a/src/main/java/com/capstone03/goldenglobe/checkList/CheckListService.java
+++ b/src/main/java/com/capstone03/goldenglobe/checkList/CheckListService.java
@@ -2,7 +2,6 @@ package com.capstone03.goldenglobe.checkList;
 
 import com.capstone03.goldenglobe.CheckListAuthCheck;
 import com.capstone03.goldenglobe.user.CustomUser;
-import com.capstone03.goldenglobe.user.UserRepository;
 import com.capstone03.goldenglobe.groupMemo.GroupMemo;
 import com.capstone03.goldenglobe.groupMemo.GroupMemoRepository;
 import com.capstone03.goldenglobe.listGroup.ListGroup;
@@ -18,9 +17,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -29,7 +26,6 @@ import java.util.stream.Collectors;
 public class CheckListService {
     private final CheckListRepository checkListRepository;
     private final TravelListRepository travelListRepository;
-    private final UserRepository userRepository;
     private final GroupMemoRepository groupMemoRepository;
     private final ListGroupRepository listGroupRepository;
     private final ListItemRepository listItemRepository;
@@ -50,7 +46,7 @@ public class CheckListService {
         return checkList.getListId().toString();
     }
 
-    public Map<String, Object> getCheckListDetails(Long destId, Authentication auth) {
+    public CheckListResponseDTO getCheckListDetails(Long destId, Authentication auth) {
         // 1. dest_id로 CheckList 조회
         Optional<CheckList> optionalCheckList = checkListRepository.findByDest_DestId(destId);
         if (optionalCheckList.isEmpty()) {
@@ -58,8 +54,6 @@ public class CheckListService {
         }
 
         CheckList checkList = optionalCheckList.get();
-        Map<String, Object> data = new HashMap<>();
-        data.put("checklist", List.of(Map.of("list_id", checkList.getListId().toString())));
 
         // 유저 권한 확인 절차
         if (!authCheck.hasAccessToCheckList(checkList.getListId(), auth)) {
@@ -70,50 +64,42 @@ public class CheckListService {
         List<ListGroup> listGroups = listGroupRepository.findByList_ListId(checkList.getListId());
 
         // 3. GroupMemo 조회 및 4. ListItem 조회
-        List<Map<String, Object>> groupsData = listGroups.stream().map(group -> {
+        List<GroupResponseDTO> groupsData = listGroups.stream().map(group -> {
             // GroupMemo 조회
-            Optional<GroupMemo> GroupMemo = groupMemoRepository.findByGroup_GroupId(group.getGroupId());
+            Optional<GroupMemo> groupMemo = groupMemoRepository.findByGroup_GroupId(group.getGroupId());
 
             // ListItem 조회
             List<ListItem> listItems = listItemRepository.findByGroup_GroupId(group.getGroupId());
 
-            // Map으로 구성
-            Map<String, Object> groupData = new HashMap<>();
-            groupData.put("group_id", group.getGroupId().toString());
-            groupData.put("group_name", group.getGroupName());
+            // GroupResponseDto 생성
+            GroupResponseDTO groupResponse = new GroupResponseDTO();
+            groupResponse.setGroupId(group.getGroupId().toString());
+            groupResponse.setGroupName(group.getGroupName());
 
             // GroupMemo가 존재하는 경우
-            GroupMemo.ifPresent(memo -> {
-                groupData.put("memo_id", memo.getMemoId().toString());
-                groupData.put("memo", memo.getMemo());
+            groupMemo.ifPresent(memo -> {
+                groupResponse.setMemoId(memo.getMemoId().toString());
+                groupResponse.setMemo(memo.getMemo());
             });
 
             // ListItem을 포함하는 항목 구성
-            List<Map<String, Object>> itemsData = listItems.stream().map(item -> {
-                Map<String, Object> itemData = new HashMap<>();
-                itemData.put("item_id", item.getItemId().toString());
-                itemData.put("item_name", item.getItem());
-                itemData.put("check", item.isChecked());
+            List<ItemResponseDTO> itemsData = listItems.stream().map(item -> {
+                ItemResponseDTO itemResponse = new ItemResponseDTO();
+                itemResponse.setItemId(item.getItemId().toString());
+                itemResponse.setItemName(item.getItem());
+                itemResponse.setCheck(item.isChecked());
 
                 // user가 null인 경우 처리
-                if (item.getUser() != null) {
-                    itemData.put("user_id", item.getUser().getUserId().toString());
-                } else {
-                    itemData.put("user_id", null); // 또는 "user_id", "null" 등을 사용할 수 있습니다.
-                }
-                return itemData;
+                itemResponse.setUserId(item.getUser() != null ? item.getUser().getUserId().toString() : null);
+
+                return itemResponse;
             }).collect(Collectors.toList());
 
-            groupData.put("items", itemsData);
-            return groupData;
+            groupResponse.setItems(itemsData);
+            return groupResponse;
         }).collect(Collectors.toList());
 
-        // 응답 데이터 구성
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "체크리스트 조회 성공");
-        data.put("groups", groupsData);
-        response.put("data", data);
-        return response;
+        // CheckListResponseDto 생성
+        return new CheckListResponseDTO(checkList.getListId().toString(), groupsData);
     }
 }

--- a/src/main/java/com/capstone03/goldenglobe/checkList/GroupResponseDTO.java
+++ b/src/main/java/com/capstone03/goldenglobe/checkList/GroupResponseDTO.java
@@ -1,0 +1,20 @@
+package com.capstone03.goldenglobe.checkList;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GroupResponseDTO {
+    private String groupId;
+    private String groupName;
+    private String memoId;
+    private String memo;
+    private List<ItemResponseDTO> items;
+}

--- a/src/main/java/com/capstone03/goldenglobe/checkList/ItemResponseDTO.java
+++ b/src/main/java/com/capstone03/goldenglobe/checkList/ItemResponseDTO.java
@@ -1,0 +1,17 @@
+package com.capstone03.goldenglobe.checkList;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemResponseDTO {
+    private String itemId;
+    private String itemName;
+    private boolean check;
+    private String userId;
+}

--- a/src/main/java/com/capstone03/goldenglobe/groupMemo/GroupMemoController.java
+++ b/src/main/java/com/capstone03/goldenglobe/groupMemo/GroupMemoController.java
@@ -1,6 +1,7 @@
 package com.capstone03.goldenglobe.groupMemo;
 
 
+import com.capstone03.goldenglobe.ApiResponse;
 import com.capstone03.goldenglobe.listGroup.ListGroupDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -22,45 +23,27 @@ public class GroupMemoController {
     private final GroupMemoRepository groupMemoRepository;
     @PostMapping("/checklists/{group_id}/memos")
     @Operation(summary = "메모 생성",description = "그룹Id를 이용해 메모 생성")
-    public ResponseEntity<Map<String, Object>> postMemo(@PathVariable("group_id") Long groupId, @RequestParam String memo, Authentication auth) {
+    public ResponseEntity<ApiResponse<GroupMemoDTO>> postMemo(@PathVariable("group_id") Long groupId, @RequestParam String memo, Authentication auth) {
         GroupMemo groupMemo = groupMemoService.makeMemo(groupId,memo, auth);
-
-        // 응답 준비
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "메모 입력완료");
-
         GroupMemoDTO toDto = GroupMemoDTO.fromEntity(groupMemo);
-        response.put("memo",toDto);
-
+        ApiResponse<GroupMemoDTO> response = new ApiResponse<>(200,"메모 입력 완료", toDto);
         return ResponseEntity.ok(response);
     }
 
     @PutMapping("/checklists/{group_id}/memos")
     @Operation(summary = "메모 수정",description = "그룹Id로 메모 내용 수정")
-    public ResponseEntity<Map<String, Object>> editMemo(@PathVariable("group_id") Long groupId, @RequestParam String memo, Authentication auth){
+    public ResponseEntity<ApiResponse<GroupMemoDTO>> editMemo(@PathVariable("group_id") Long groupId, @RequestParam String memo, Authentication auth){
         GroupMemo updatedMemo = groupMemoService.editMemo(groupId, memo, auth);
-        // 응답 준비
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "메모 변경 완료");
-
-        GroupMemoDTO updated = GroupMemoDTO.fromEntity(updatedMemo);
-        response.put("memo",updated);
-
+        GroupMemoDTO toDto = GroupMemoDTO.fromEntity(updatedMemo);
+        ApiResponse<GroupMemoDTO> response = new ApiResponse<>(200,"메모 수정 완료", toDto);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/checklists/memos")
     @Operation(summary = "메모 삭제",description = "메모Id로 메모 삭제")
-    public ResponseEntity<Map<String, Object>> deleteItem(@RequestParam("memo_id") Long memoId, Authentication auth) {
-
+    public ResponseEntity<ApiResponse<Void>> deleteItem(@RequestParam("memo_id") Long memoId, Authentication auth) {
         groupMemoService.deleteMemo(memoId, auth);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "메모 삭제 완료");
-
+        ApiResponse<Void> response = new ApiResponse<>(200, "메모 삭제 완료", null);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/capstone03/goldenglobe/groupMemo/GroupMemoController.java
+++ b/src/main/java/com/capstone03/goldenglobe/groupMemo/GroupMemoController.java
@@ -2,6 +2,8 @@ package com.capstone03.goldenglobe.groupMemo;
 
 
 import com.capstone03.goldenglobe.listGroup.ListGroupDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -13,11 +15,13 @@ import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
+@Tag(name="GroupMemo",description = "그룹 메모  API")
 public class GroupMemoController {
 
     private final GroupMemoService groupMemoService;
     private final GroupMemoRepository groupMemoRepository;
     @PostMapping("/checklists/{group_id}/memos")
+    @Operation(summary = "메모 생성",description = "그룹Id를 이용해 메모 생성")
     public ResponseEntity<Map<String, Object>> postMemo(@PathVariable("group_id") Long groupId, @RequestParam String memo, Authentication auth) {
         GroupMemo groupMemo = groupMemoService.makeMemo(groupId,memo, auth);
 
@@ -33,6 +37,7 @@ public class GroupMemoController {
     }
 
     @PutMapping("/checklists/{group_id}/memos")
+    @Operation(summary = "메모 수정",description = "그룹Id로 메모 내용 수정")
     public ResponseEntity<Map<String, Object>> editMemo(@PathVariable("group_id") Long groupId, @RequestParam String memo, Authentication auth){
         GroupMemo updatedMemo = groupMemoService.editMemo(groupId, memo, auth);
         // 응답 준비
@@ -47,6 +52,7 @@ public class GroupMemoController {
     }
 
     @DeleteMapping("/checklists/memos")
+    @Operation(summary = "메모 삭제",description = "메모Id로 메모 삭제")
     public ResponseEntity<Map<String, Object>> deleteItem(@RequestParam("memo_id") Long memoId, Authentication auth) {
 
         groupMemoService.deleteMemo(memoId, auth);

--- a/src/main/java/com/capstone03/goldenglobe/groupMemo/GroupMemoService.java
+++ b/src/main/java/com/capstone03/goldenglobe/groupMemo/GroupMemoService.java
@@ -29,7 +29,7 @@ public class GroupMemoService {
             return groupMemoRepository.save(groupMemo);
         } catch (DataIntegrityViolationException e) { // 무결성 위반 -> 중복된 그룹에 메모 추가하려고 할 때
             // DuplicateKeyException e 유니크 제약 조건 위반
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "데이터 무결성 위반", e);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "데이터 무결성 위반: " +e.getMessage());
         }
     }
 
@@ -41,7 +41,7 @@ public class GroupMemoService {
             groupMemo.setMemo(memo);
             return groupMemoRepository.save(groupMemo);
         } else {
-            throw new IllegalArgumentException("해당 group_id로 메모를 찾을 수 없습니다. 메모를 먼저 생성해주세요");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "해당 group_id로 메모를 찾을 수 없습니다. 메모를 먼저 생성해주세요");
         }
     }
 

--- a/src/main/java/com/capstone03/goldenglobe/groupMemo/GroupMemoService.java
+++ b/src/main/java/com/capstone03/goldenglobe/groupMemo/GroupMemoService.java
@@ -3,6 +3,7 @@ package com.capstone03.goldenglobe.groupMemo;
 import com.capstone03.goldenglobe.CheckListAuthCheck;
 import com.capstone03.goldenglobe.listGroup.ListGroup;
 import com.capstone03.goldenglobe.listGroup.ListGroupRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -45,6 +46,7 @@ public class GroupMemoService {
         }
     }
 
+    // 삭제가 제대로 작동 x
     public void deleteMemo(Long memoId, Authentication auth) {
         // 메모 조회 및 존재하지 않을 경우 예외 처리
         GroupMemo groupMemo = groupMemoRepository.findById(memoId)
@@ -52,12 +54,10 @@ public class GroupMemoService {
 
         // ListGroup 조회
         ListGroup listGroup = groupMemo.getGroup();
-
         // 유저 권한 확인 절차
         if (!authCheck.hasAccessToCheckList(listGroup.getList().getListId(), auth)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "체크리스트에 접근할 수 없습니다.");
         }
-
         // 메모 삭제
         groupMemoRepository.deleteById(memoId);
     }

--- a/src/main/java/com/capstone03/goldenglobe/listGroup/ListGroupController.java
+++ b/src/main/java/com/capstone03/goldenglobe/listGroup/ListGroupController.java
@@ -1,5 +1,6 @@
 package com.capstone03.goldenglobe.listGroup;
 
+import com.capstone03.goldenglobe.ApiResponse;
 import com.capstone03.goldenglobe.listItem.ListItemDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -25,44 +26,27 @@ public class ListGroupController {
 
     @PostMapping("/checklists/{list_id}/groups")
     @Operation(summary="그룹 생성", description = "체크리스트Id에 속하는 그룹 생성")
-    public ResponseEntity<Map<String, Object>> postGroup(@PathVariable("list_id") Long listId, @RequestParam("group_name") String groupName, Authentication auth) {
+    public ResponseEntity<ApiResponse<ListGroupDTO>> postGroup(@PathVariable("list_id") Long listId, @RequestParam("group_name") String groupName, Authentication auth) {
         ListGroup listGroup = listGroupService.makeGroup(listId,groupName, auth);
-
-        // 응답 준비
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "그룹 추가 성공");
-
         ListGroupDTO toDto = ListGroupDTO.fromEntity(listGroup);
-        response.put("group",toDto);
-
+        ApiResponse<ListGroupDTO> response = new ApiResponse<>(200,"그룹 생성 성공",toDto);
         return ResponseEntity.ok(response);
     }
 
     @PutMapping("/checklists/groups/{group_id}")
     @Operation(summary = "그룹 이름 수정",description = "그룹Id로 그룹 이름 수정")
-    public ResponseEntity<Map<String, Object>> editGroupName(@PathVariable("group_id") Long groupId, @RequestParam("group_name") String groupName, Authentication auth){
+    public ResponseEntity<ApiResponse<ListGroupDTO>> editGroupName(@PathVariable("group_id") Long groupId, @RequestParam("group_name") String groupName, Authentication auth){
         ListGroup updatedGroup = listGroupService.editGroupName(groupId, groupName, auth);
-        // 응답 준비
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "그룹 이름 변경 성공");
-
-        ListGroupDTO updated = ListGroupDTO.fromEntity(updatedGroup);
-        response.put("group",updated);
-
+        ListGroupDTO toDto = ListGroupDTO.fromEntity(updatedGroup);
+        ApiResponse<ListGroupDTO> response = new ApiResponse<>(200,"그룹 이름 변경 성공",toDto);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/checklists/groups")
     @Operation(summary = "그룹 삭제",description = "그룹Id로 그룹 삭제")
-    public ResponseEntity<Map<String, Object>> deleteItem(@RequestParam("group_id") Long groupId,Authentication auth) {
+    public ResponseEntity<ApiResponse<Void>> deleteItem(@RequestParam("group_id") Long groupId,Authentication auth) {
         listGroupService.deleteGroup(groupId, auth);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "그룹 삭제 완료 (그룹 메모, 아이템 포함)");
-
+        ApiResponse<Void> response = new ApiResponse<>(200, "그룹 삭제 완료(메모, 항목 포함)", null);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/capstone03/goldenglobe/listGroup/ListGroupController.java
+++ b/src/main/java/com/capstone03/goldenglobe/listGroup/ListGroupController.java
@@ -1,6 +1,8 @@
 package com.capstone03.goldenglobe.listGroup;
 
 import com.capstone03.goldenglobe.listItem.ListItemDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,12 +17,14 @@ import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
+@Tag(name="ListGroup",description = "체크리스트 내 그룹 API")
 public class ListGroupController {
 
     private final ListGroupService listGroupService;
     private final ListGroupRepository listGroupRepository;
 
     @PostMapping("/checklists/{list_id}/groups")
+    @Operation(summary="그룹 생성", description = "체크리스트Id에 속하는 그룹 생성")
     public ResponseEntity<Map<String, Object>> postGroup(@PathVariable("list_id") Long listId, @RequestParam("group_name") String groupName, Authentication auth) {
         ListGroup listGroup = listGroupService.makeGroup(listId,groupName, auth);
 
@@ -36,6 +40,7 @@ public class ListGroupController {
     }
 
     @PutMapping("/checklists/groups/{group_id}")
+    @Operation(summary = "그룹 이름 수정",description = "그룹Id로 그룹 이름 수정")
     public ResponseEntity<Map<String, Object>> editGroupName(@PathVariable("group_id") Long groupId, @RequestParam("group_name") String groupName, Authentication auth){
         ListGroup updatedGroup = listGroupService.editGroupName(groupId, groupName, auth);
         // 응답 준비
@@ -50,6 +55,7 @@ public class ListGroupController {
     }
 
     @DeleteMapping("/checklists/groups")
+    @Operation(summary = "그룹 삭제",description = "그룹Id로 그룹 삭제")
     public ResponseEntity<Map<String, Object>> deleteItem(@RequestParam("group_id") Long groupId,Authentication auth) {
         listGroupService.deleteGroup(groupId, auth);
 

--- a/src/main/java/com/capstone03/goldenglobe/listItem/ListItemController.java
+++ b/src/main/java/com/capstone03/goldenglobe/listItem/ListItemController.java
@@ -1,5 +1,7 @@
 package com.capstone03.goldenglobe.listItem;
 
+import com.capstone03.goldenglobe.ApiResponse;
+import com.capstone03.goldenglobe.groupMemo.GroupMemoDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -24,75 +26,45 @@ public class ListItemController {
 
     @PostMapping("/checklists/{list_id}/{group_id}/items")
     @Operation(summary = "항목 추가",description = "그룹Id에 속하는 아이템 추가")
-    public ResponseEntity<Map<String, Object>> postItem(@PathVariable("list_id") Long listId, @PathVariable("group_id") Long groupId, @RequestParam("item_name") String itemName, Authentication auth) {
-
+    public ResponseEntity<ApiResponse<ListItemDTO>> postItem(@PathVariable("list_id") Long listId, @PathVariable("group_id") Long groupId, @RequestParam("item_name") String itemName, Authentication auth) {
         ListItem listItem = listItemService.makeItem(listId, groupId, itemName, auth);
-
-        // 응답 준비
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "항목 추가 완료");
-
         ListItemDTO toDto = ListItemDTO.fromEntity(listItem);
-        response.put("item", toDto);
-
+        ApiResponse<ListItemDTO> response = new ApiResponse<>(200,"항목 추가 완료",toDto);
         return ResponseEntity.ok(response);
     }
 
     @PutMapping("/checklists/items/{item_id}/name")
     @Operation(summary = "항목 수정",description = "항목Id로 아이템 수정")
-    public ResponseEntity<Map<String, Object>> editItemName(@PathVariable("item_id") Long itemId, @RequestParam("item_name") String itemName, Authentication auth){
+    public ResponseEntity<ApiResponse<ListItemDTO>> editItemName(@PathVariable("item_id") Long itemId, @RequestParam("item_name") String itemName, Authentication auth){
         ListItem updatedItem = listItemService.editItemName(itemId, itemName,auth);
-        // 응답 준비
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "항목 변경 완료");
-
-        ListItemDTO updated = ListItemDTO.fromEntity(updatedItem);
-        response.put("item", updated);
-
+        ListItemDTO toDto = ListItemDTO.fromEntity(updatedItem);
+        ApiResponse<ListItemDTO> response = new ApiResponse<>(200,"항목 변경 완료",toDto);
         return ResponseEntity.ok(response);
     }
 
     @PutMapping("/checklists/items/{item_id}/checked")
     @Operation(summary = "항목 체크/체크 해제",description = "항목Id로 항목을 체크/체크해제. 항목 체크 시 체크한 유저Id 기재")
-    public ResponseEntity<Map<String, Object>> editItemChecked(@PathVariable("item_id") Long itemId, Authentication auth){
+    public ResponseEntity<ApiResponse<ListItemDTO>> editItemChecked(@PathVariable("item_id") Long itemId, Authentication auth){
         ListItem updatedItem = listItemService.editItemChecked(itemId, auth);
-        // 응답 준비
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "체크/체크해제 변경 완료");
-
-        ListItemDTO updated = ListItemDTO.fromEntity(updatedItem);
-        response.put("item", updated);
-
+        ListItemDTO toDto = ListItemDTO.fromEntity(updatedItem);
+        ApiResponse<ListItemDTO> response = new ApiResponse<>(200,"체크/체크해제 변경 완료", toDto);
         return ResponseEntity.ok(response);
     }
 
     @PutMapping("/checklists/items/{item_id}/groups")
     @Operation(summary = "항목 그룹 변경",description = "항목Id와 새 그룹Id로 항목의 그룹을 변경")
-    public ResponseEntity<Map<String, Object>> editItemGroup(@PathVariable("item_id") Long itemId, @RequestParam("new_group_id") Long newGroupId, Authentication auth){
+    public ResponseEntity<ApiResponse<ListItemDTO>> editItemGroup(@PathVariable("item_id") Long itemId, @RequestParam("new_group_id") Long newGroupId, Authentication auth){
         ListItem updatedItem = listItemService.editItemGroup(itemId, newGroupId,auth);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "그룹 변경 완료");
-
-        ListItemDTO updated = ListItemDTO.fromEntity(updatedItem);
-        response.put("item", updated);
-
+        ListItemDTO toDto = ListItemDTO.fromEntity(updatedItem);
+        ApiResponse<ListItemDTO> response = new ApiResponse<>(200,"그룹 변경 완료", toDto);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/checklists/items")
     @Operation(summary = "항목 삭제",description = "항목Id로 항목 삭제")
-    public ResponseEntity<Map<String, Object>> deleteItem(@RequestParam("item_id") Long itemId,Authentication auth) {
+    public ResponseEntity<ApiResponse<Void>> deleteItem(@RequestParam("item_id") Long itemId,Authentication auth) {
         listItemService.deleteItem(itemId,auth);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "항목 삭제 완료");
-
+        ApiResponse<Void> response = new ApiResponse<>(200, "항목 삭제 완료", null);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/capstone03/goldenglobe/listItem/ListItemController.java
+++ b/src/main/java/com/capstone03/goldenglobe/listItem/ListItemController.java
@@ -1,5 +1,7 @@
 package com.capstone03.goldenglobe.listItem;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -12,6 +14,7 @@ import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
+@Tag(name="ListItem",description = "체크리스트 항목(아이템) API")
 public class ListItemController {
 
     private final ListItemService listItemService;
@@ -20,6 +23,7 @@ public class ListItemController {
 
 
     @PostMapping("/checklists/{list_id}/{group_id}/items")
+    @Operation(summary = "항목 추가",description = "그룹Id에 속하는 아이템 추가")
     public ResponseEntity<Map<String, Object>> postItem(@PathVariable("list_id") Long listId, @PathVariable("group_id") Long groupId, @RequestParam("item_name") String itemName, Authentication auth) {
 
         ListItem listItem = listItemService.makeItem(listId, groupId, itemName, auth);
@@ -36,6 +40,7 @@ public class ListItemController {
     }
 
     @PutMapping("/checklists/items/{item_id}/name")
+    @Operation(summary = "항목 수정",description = "항목Id로 아이템 수정")
     public ResponseEntity<Map<String, Object>> editItemName(@PathVariable("item_id") Long itemId, @RequestParam("item_name") String itemName, Authentication auth){
         ListItem updatedItem = listItemService.editItemName(itemId, itemName,auth);
         // 응답 준비
@@ -50,6 +55,7 @@ public class ListItemController {
     }
 
     @PutMapping("/checklists/items/{item_id}/checked")
+    @Operation(summary = "항목 체크/체크 해제",description = "항목Id로 항목을 체크/체크해제. 항목 체크 시 체크한 유저Id 기재")
     public ResponseEntity<Map<String, Object>> editItemChecked(@PathVariable("item_id") Long itemId, Authentication auth){
         ListItem updatedItem = listItemService.editItemChecked(itemId, auth);
         // 응답 준비
@@ -64,6 +70,7 @@ public class ListItemController {
     }
 
     @PutMapping("/checklists/items/{item_id}/groups")
+    @Operation(summary = "항목 그룹 변경",description = "항목Id와 새 그룹Id로 항목의 그룹을 변경")
     public ResponseEntity<Map<String, Object>> editItemGroup(@PathVariable("item_id") Long itemId, @RequestParam("new_group_id") Long newGroupId, Authentication auth){
         ListItem updatedItem = listItemService.editItemGroup(itemId, newGroupId,auth);
 
@@ -78,6 +85,7 @@ public class ListItemController {
     }
 
     @DeleteMapping("/checklists/items")
+    @Operation(summary = "항목 삭제",description = "항목Id로 항목 삭제")
     public ResponseEntity<Map<String, Object>> deleteItem(@RequestParam("item_id") Long itemId,Authentication auth) {
         listItemService.deleteItem(itemId,auth);
 

--- a/src/main/java/com/capstone03/goldenglobe/listItem/ListItemController.java
+++ b/src/main/java/com/capstone03/goldenglobe/listItem/ListItemController.java
@@ -51,6 +51,7 @@ public class ListItemController {
         return ResponseEntity.ok(response);
     }
 
+    // 체크리스트 내 그룹 Id인지 확인 필요!!!
     @PutMapping("/checklists/items/{item_id}/groups")
     @Operation(summary = "항목 그룹 변경",description = "항목Id와 새 그룹Id로 항목의 그룹을 변경")
     public ResponseEntity<ApiResponse<ListItemDTO>> editItemGroup(@PathVariable("item_id") Long itemId, @RequestParam("new_group_id") Long newGroupId, Authentication auth){

--- a/src/main/java/com/capstone03/goldenglobe/listItem/ListItemService.java
+++ b/src/main/java/com/capstone03/goldenglobe/listItem/ListItemService.java
@@ -3,7 +3,6 @@ package com.capstone03.goldenglobe.listItem;
 import com.capstone03.goldenglobe.CheckListAuthCheck;
 import com.capstone03.goldenglobe.checkList.CheckList;
 import com.capstone03.goldenglobe.checkList.CheckListRepository;
-import com.capstone03.goldenglobe.groupMemo.GroupMemo;
 import com.capstone03.goldenglobe.listGroup.ListGroup;
 import com.capstone03.goldenglobe.listGroup.ListGroupRepository;
 import com.capstone03.goldenglobe.user.CustomUser;
@@ -31,7 +30,7 @@ public class ListItemService {
 
         // 일치하는 체크리스트가 있는지 확인
         CheckList checkList = checkListRepository.findById(listId)
-                .orElseThrow(() -> new IllegalArgumentException("일치하는 list_id가 없음"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "일치하는 list_id가 없음"));
 
         // 일치하는 그룹이 있는지 확인
         ListGroup listGroup = authCheck.findAndCheckAccessToGroup(groupId,auth);
@@ -56,7 +55,7 @@ public class ListItemService {
         listItem.setChecked(!listItem.isChecked());
          if(listItem.isChecked()){ // true
              CustomUser customUser = (CustomUser) auth.getPrincipal();
-             var userPhone = customUser.getCellphone();
+             String userPhone = customUser.getCellphone();
              User user = userRepository.findByCellphone(userPhone)
                      .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "유저를 찾을 수 없습니다."));
 
@@ -75,7 +74,7 @@ public class ListItemService {
             listItem.setGroup(group.get());
             return listItemRepository.save(listItem);
         } else {
-            throw new IllegalArgumentException("일치하는 group_id가 없음");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "일치하는 group_id가 없음");
         }
     }
 

--- a/src/main/java/com/capstone03/goldenglobe/profileImage/ProfileController.java
+++ b/src/main/java/com/capstone03/goldenglobe/profileImage/ProfileController.java
@@ -1,5 +1,6 @@
 package com.capstone03.goldenglobe.profileImage;
 
+import com.capstone03.goldenglobe.ApiResponse;
 import com.capstone03.goldenglobe.user.CustomUser;
 import com.capstone03.goldenglobe.user.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,30 +25,33 @@ public class ProfileController {
     // Presigned URL 생성
     @PostMapping("/users/profile/url")
     @Operation(summary = "PresignedURL 생성",description = "PresignedURL과 해당 URL을 통해 정상적으로 이미지 업로드 시, 이미지를 조회할 수 있는 URL을 반환합니다.")
-    public ResponseEntity<ProfileDto> updateProfile(Authentication auth){
-        ProfileDto response = profileService.getPresignedUrl(auth);
+    public ResponseEntity<ApiResponse<ProfileDto>> updateProfile(Authentication auth){
+        ProfileDto toDto = profileService.getPresignedUrl(auth);
+        ApiResponse<ProfileDto> response = new ApiResponse<>(HttpStatus.OK.value(), "Presigned URL 생성 완료", toDto);
         return ResponseEntity.ok(response);
     }
 
     // 이미지 조회
     @GetMapping("/users/profile")
     @Operation(summary = "이미지 조회 URL 생성",description = "로그인한 유저의 프로필 이미지 URL정보를 가져옵니다.")
-    public ResponseEntity<String> getProfile(Authentication auth){
+    public ResponseEntity<ApiResponse<String>> getProfile(Authentication auth){
         String profileUrl = profileService.getProfileUrl(auth);
-        return ResponseEntity.ok(profileUrl);
+        ApiResponse<String> response = new ApiResponse<>(HttpStatus.OK.value(), "프로필 이미지 URL 조회 완료", profileUrl);
+        return ResponseEntity.ok(response);
     }
 
     // S3 직접 업로드
     @PostMapping("/users/profile/image")
     @Operation(summary = "서버에서 이미지 직접 업로드",description = "서버가 프론트에서 이미지를 받아 S3 bucket에 이미지를 업로드합니다.")
-    public ResponseEntity<?> uploadProfileImage(Authentication auth,
+    public ResponseEntity<ApiResponse<?>> uploadProfileImage(Authentication auth,
                                                      @RequestParam("file") MultipartFile file) {
         try {
-            ProfileDto response = profileService.uploadProfileImage(auth, file);
+            ProfileDto toDto = profileService.uploadProfileImage(auth, file);
+            ApiResponse<ProfileDto> response = new ApiResponse<>(HttpStatus.OK.value(), "이미지 업로드 성공", toDto);
             return ResponseEntity.ok(response);
         } catch (IOException e) {
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body("업로드 실패");
+            ApiResponse<String> response = new ApiResponse<>(HttpStatus.INTERNAL_SERVER_ERROR.value(), "업로드 실패", null);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
         }
     }
 }

--- a/src/main/java/com/capstone03/goldenglobe/profileImage/ProfileController.java
+++ b/src/main/java/com/capstone03/goldenglobe/profileImage/ProfileController.java
@@ -2,6 +2,8 @@ package com.capstone03.goldenglobe.profileImage;
 
 import com.capstone03.goldenglobe.user.CustomUser;
 import com.capstone03.goldenglobe.user.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,12 +16,14 @@ import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "ProfileImage",description = "유저 프로필 이미지 관련 API")
 public class ProfileController {
 
     private final ProfileService profileService;
 
     // Presigned URL 생성
     @PostMapping("/users/profile/url")
+    @Operation(summary = "PresignedURL 생성",description = "PresignedURL과 해당 URL을 통해 정상적으로 이미지 업로드 시, 이미지를 조회할 수 있는 URL을 반환합니다.")
     public ResponseEntity<ProfileDto> updateProfile(Authentication auth){
         ProfileDto response = profileService.getPresignedUrl(auth);
         return ResponseEntity.ok(response);
@@ -27,6 +31,7 @@ public class ProfileController {
 
     // 이미지 조회
     @GetMapping("/users/profile")
+    @Operation(summary = "이미지 조회 URL 생성",description = "로그인한 유저의 프로필 이미지 URL정보를 가져옵니다.")
     public ResponseEntity<String> getProfile(Authentication auth){
         String profileUrl = profileService.getProfileUrl(auth);
         return ResponseEntity.ok(profileUrl);
@@ -34,6 +39,7 @@ public class ProfileController {
 
     // S3 직접 업로드
     @PostMapping("/users/profile/image")
+    @Operation(summary = "서버에서 이미지 직접 업로드",description = "서버가 프론트에서 이미지를 받아 S3 bucket에 이미지를 업로드합니다.")
     public ResponseEntity<?> uploadProfileImage(Authentication auth,
                                                      @RequestParam("file") MultipartFile file) {
         try {

--- a/src/main/java/com/capstone03/goldenglobe/profileImage/ProfileService.java
+++ b/src/main/java/com/capstone03/goldenglobe/profileImage/ProfileService.java
@@ -10,9 +10,11 @@ import com.capstone03.goldenglobe.user.User;
 import com.capstone03.goldenglobe.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.util.Date;
@@ -34,9 +36,7 @@ public class ProfileService {
 
         // url 만료시간 설정
         Date expiration = new Date();
-        long expTime = expiration.getTime();
-        expTime += 1000*60*5 ; // 5분 후 만료
-        expiration.setTime(expTime);
+        expiration.setTime(expiration.getTime() + 1000*60*5); // 5분 후 만료
 
         // presigned URL 생성
         GeneratePresignedUrlRequest generatePresignedUrlRequest =
@@ -51,7 +51,7 @@ public class ProfileService {
             user.get().setProfile(fileName);
             userRepository.save(user.get());
         } else {
-            throw new RuntimeException("사용자를 찾을 수 없습니다.");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
         }
 
         String profileUrl = "https://"+bucket+".s3.ap-northeast-2.amazonaws.com/"+fileName;
@@ -79,7 +79,7 @@ public class ProfileService {
             user.get().setProfile(fileName);
             userRepository.save(user.get());
         } else {
-            throw new RuntimeException("사용자를 찾을 수 없습니다.");
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
         }
         String profileUrl = "https://"+bucket+".s3.ap-northeast-2.amazonaws.com/"+fileName;
         return new ProfileDto(null,profileUrl);

--- a/src/main/java/com/capstone03/goldenglobe/sharedList/SharedListController.java
+++ b/src/main/java/com/capstone03/goldenglobe/sharedList/SharedListController.java
@@ -1,7 +1,10 @@
 package com.capstone03.goldenglobe.sharedList;
 
+import com.capstone03.goldenglobe.ApiResponse;
 import com.capstone03.goldenglobe.listGroup.ListGroup;
 import com.capstone03.goldenglobe.listItem.ListItemDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -13,60 +16,44 @@ import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
+@Tag(name="SharedList",description = "체크리스트 공유 관련 API")
 public class SharedListController {
 
     private final SharedListService sharedListService;
 
     @PostMapping("/checklists/share/{list_id}")
-    public ResponseEntity<Map<String, Object>> postGroup(@PathVariable("list_id") Long listId, @RequestParam("user_id") Long userId, Authentication auth) {
+    @Operation(summary = "체크리스트 공유",description = "유저Id를 입력받아 해당 유저와 체크리스트를 공유")
+    public ResponseEntity<ApiResponse<Void>> postGroup(@PathVariable("list_id") Long listId, @RequestParam("user_id") Long userId, Authentication auth) {
         sharedListService.addUser(listId, userId, auth);
-
-        // 응답 준비
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "체크리스트 공유 성공");
-
+        ApiResponse<Void> response = new ApiResponse<>(200,"체크리스트 공유 성공");
         return ResponseEntity.ok(response);
     }
 
     @PutMapping("/checklists/share/{list_id}/color")
-    public ResponseEntity<Map<String, Object>> changeColor(@PathVariable("list_id") Long listId, @RequestParam("user_color") String userColor, Authentication auth) {
+    @Operation(summary = "공유 색상 변경",description = "체크리스트에서 표시되는 색상을 변경합니다.")
+    public ResponseEntity<ApiResponse<SharedListDTO>> changeColor(@PathVariable("list_id") Long listId, @RequestParam("user_color") String userColor, Authentication auth) {
         SharedList updatedShared = sharedListService.changeColor(listId, userColor, auth);
-
-        // 응답 준비
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "공유 색상 변경");
-
-        SharedListDTO updated = SharedListDTO.fromEntity(updatedShared);
-        response.put("updatedShared", updated);
-
+        SharedListDTO toDto = SharedListDTO.fromEntity(updatedShared);
+        ApiResponse<SharedListDTO> response = new ApiResponse<>(200,"공유 색상 변경",toDto);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/checklists/share/{list_id}") // 공유 설정 해제
-    public ResponseEntity<Map<String, Object>> deleteShare(@PathVariable("list_id") Long listId, Authentication auth) {
+    @Operation(summary = "공유 해제",description = "공유 받은 체크리스트를 해제합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteShare(@PathVariable("list_id") Long listId, Authentication auth) {
         // 삭제 처리 service 함수
         sharedListService.deleteShare(listId,auth);
-
-        // 응답 준비
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "공유 해제");
-
+        ApiResponse<Void> response = new ApiResponse<>(200,"공유 해제 성공");
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/checklists/share/{list_id}/{user_id}") // 공유 설정 해제
-    public ResponseEntity<Map<String, Object>> deleteShare(@PathVariable("list_id") Long listId, @PathVariable("user_id") Long userId, Authentication auth) {
+    @Operation(summary = "특정 사용자의 공유 해제",description = "공유한 유저가 더 이상 체크리스트에 접근할 수 없게 공유를 해제합니다.")
+    public ResponseEntity<ApiResponse<Void>> deleteShare(@PathVariable("list_id") Long listId, @PathVariable("user_id") Long userId, Authentication auth) {
         // 삭제 처리 service 함수
         sharedListService.deleteShareOwner(listId, userId, auth);
 
-        // 응답 준비
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("message", "공유 해제");
-
+        ApiResponse<Void> response = new ApiResponse<>(200,"공유 해제 성공");
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/capstone03/goldenglobe/sharedList/SharedListService.java
+++ b/src/main/java/com/capstone03/goldenglobe/sharedList/SharedListService.java
@@ -30,7 +30,7 @@ public class SharedListService {
         sharedList.setList(checkList);
 
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("일치하는 user_id가 없음"));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "일치하는 user_id가 없음"));
         sharedList.setUser(user);
 
         return sharedListRepository.save(sharedList);

--- a/src/main/java/com/capstone03/goldenglobe/sms/SmsController.java
+++ b/src/main/java/com/capstone03/goldenglobe/sms/SmsController.java
@@ -1,5 +1,7 @@
 package com.capstone03.goldenglobe.sms;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -12,11 +14,13 @@ import java.util.Map;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/sms")
+@Tag(name="Sms",description = "휴대폰 인증 관련 API")
 public class SmsController {
 
     private final SmsService smsService;
 
     @PostMapping("/send")
+    @Operation(summary = "인증번호 전송",description = "전달받은 휴대폰 번호로 인증번호를 전송합니다.")
     public ResponseEntity<Map<String, Object>> SendSMS(@RequestBody @Valid SmsDto smsDto){
         String certificationCode = smsService.SendSms(smsDto);
 
@@ -29,6 +33,7 @@ public class SmsController {
     }
 
     @PostMapping("/verify")
+    @Operation(summary = "인증번호 확인",description = "휴대폰 번호와 인증번호가 맞는지 확인합니다.")
     public ResponseEntity<String> verifySMS(@RequestBody @Valid SmsVerifyDto smsVerifyDto){
         boolean verify = smsService.verifyCode(smsVerifyDto);
         if (verify) {

--- a/src/main/java/com/capstone03/goldenglobe/sms/SmsController.java
+++ b/src/main/java/com/capstone03/goldenglobe/sms/SmsController.java
@@ -1,5 +1,6 @@
 package com.capstone03.goldenglobe.sms;
 
+import com.capstone03.goldenglobe.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -21,25 +22,23 @@ public class SmsController {
 
     @PostMapping("/send")
     @Operation(summary = "인증번호 전송",description = "전달받은 휴대폰 번호로 인증번호를 전송합니다.")
-    public ResponseEntity<Map<String, Object>> SendSMS(@RequestBody @Valid SmsDto smsDto){
+    public ResponseEntity<ApiResponse<SmsResponseDto>> SendSMS(@RequestBody @Valid SmsDto smsDto){
         String certificationCode = smsService.SendSms(smsDto);
-
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("phoneNumber", smsDto.getCellPhone());
-        response.put("code", certificationCode);
-        response.put("message", "문자 전송 완료");
+        SmsResponseDto responseDto = new SmsResponseDto(smsDto.getCellPhone(), certificationCode);
+        ApiResponse<SmsResponseDto> response = new ApiResponse<>(200, "문자 전송 완료", responseDto);
         return ResponseEntity.ok(response);
     }
 
     @PostMapping("/verify")
     @Operation(summary = "인증번호 확인",description = "휴대폰 번호와 인증번호가 맞는지 확인합니다.")
-    public ResponseEntity<String> verifySMS(@RequestBody @Valid SmsVerifyDto smsVerifyDto){
+    public ResponseEntity<ApiResponse<Void>> verifySMS(@RequestBody @Valid SmsVerifyDto smsVerifyDto){
         boolean verify = smsService.verifyCode(smsVerifyDto);
         if (verify) {
-            return ResponseEntity.ok("인증 완료 되었습니다.");
+            ApiResponse<Void> response = new ApiResponse<>(200, "인증 완료", null);
+            return ResponseEntity.ok(response);
         } else {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("인증에 실패했습니다.");
+            ApiResponse<Void> response = new ApiResponse<>(400, "인증 실패", null);
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
         }
     }
 }

--- a/src/main/java/com/capstone03/goldenglobe/sms/SmsResponseDto.java
+++ b/src/main/java/com/capstone03/goldenglobe/sms/SmsResponseDto.java
@@ -1,0 +1,14 @@
+package com.capstone03.goldenglobe.sms;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SmsResponseDto {
+    private String phoneNumber;
+    private String certificationCode;
+}
+

--- a/src/main/java/com/capstone03/goldenglobe/user/User.java
+++ b/src/main/java/com/capstone03/goldenglobe/user/User.java
@@ -33,7 +33,7 @@ public class User {
   @Column(name = "nickname", length = 10)
   private String nickname;
 
-  @Column(name = "profile", length = 30)
+  @Column(name = "profile")
   private String profile;
 
   @Column(name = "gender", length = 10)


### PR DESCRIPTION
## 🗃️ : user > profile 컬럼 길이 제한 삭제
- 프로필 이미지명에 UUID를 추가하면서 `length = 30` 제한 삭제 
</br>

## ✨ : swagger 적용
- dependencies `implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'` 추가
- `Tag`,`Operation`만 1차 적용 (CheckList, GroupMemo, ListGroup, ListItem, ProfileImage, Sms, SharedList)
</br>

## ♻️ : response 통일
- `ApiResponse`로 응답 통일 (status, message, data)
- MyExceptionHandler, CheckList, GroupMemo, ListGroup, ListItem, ProfileImage, Sms, SharedList 부분 응답 통일
- CheckListDTO,SmsResponseDTO 생성
</br>

## ❗ 관련해서 추가로 해결해야 할 부분
- [x] 메모 삭제 기능 작동 X
- [ ] item 그룹 변경 시, 체크리스트 내 그룹 Id인지 확인 필요
- [x] 체크리스트 조회 관련 유저 권한 체크 제대로 되는지 확인
- [ ] swagger status 수정